### PR TITLE
Game over when enemy hits player trail

### DIFF
--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -21,6 +21,15 @@ public class Enemy :MonoBehaviour {
     }
 
     private void OnTriggerEnter(Collider other) {
+        if (other.gameObject.CompareTag("PlayerTrail")) {
+            var player = FindObjectOfType<PlayerControls>();
+            if (player != null) {
+                Debug.Log("Game Over Enemy hit trail: " + other.gameObject.name);
+                player.GameOver();
+            }
+            return;
+        }
+
         if (other.gameObject.CompareTag("Ground")) {
             if (Mathf.Abs(transform.position.x) > Mathf.Abs(transform.position.z)) {
                 xDirection *= -1;

--- a/Assets/Scripts/PlayerControls.cs
+++ b/Assets/Scripts/PlayerControls.cs
@@ -120,7 +120,7 @@ public class PlayerControls :MonoBehaviour {
         trailColliders = new List<GameObject>();
     }
 
-    void GameOver() {
+    public void GameOver() {
         gameOver = true;
         explosionSound.Play();
         explosionPrefab.Play();


### PR DESCRIPTION
## Summary
- expose `GameOver` method on `PlayerControls`
- end the game if an enemy collides with the player's trail

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ce04bb58832584204cf41b5be03f